### PR TITLE
Yuji MenuItemReview GET, PUT, DELETE, 200 OK!

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -57,7 +57,7 @@ public class MenuItemReviewController extends ApiController {
         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
         // See: https://www.baeldung.com/spring-date-parameters
 
-        log.info("localDateTime={}", dateReviewed);
+        log.info("dateReviewed={}", dateReviewed);
 
         MenuItemReview menuItemReview = new MenuItemReview();
         menuItemReview.setItemId(itemId);
@@ -69,6 +69,50 @@ public class MenuItemReviewController extends ApiController {
         MenuItemReview savedMenuItemReview = menuItemReviewRepository.save(menuItemReview);
 
         return savedMenuItemReview;
+    }
+
+    @Operation(summary= "Get a single menu item review")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public MenuItemReview getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        return menuItemReview;
+    }
+
+    @Operation(summary= "Delete a MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemReviewRepository.delete(menuItemReview);
+        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+    }
+
+    @Operation(summary= "Update a single menuitemreview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public MenuItemReview updateMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid MenuItemReview incoming) {
+
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemReview.setItemId(incoming.getItemId());
+        menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+        menuItemReview.setStars(incoming.getStars());
+        menuItemReview.setDateReviewed(incoming.getDateReviewed());
+        menuItemReview.setComments(incoming.getComments());
+
+        menuItemReviewRepository.save(menuItemReview);
+
+        return menuItemReview;
     }
     
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -20,8 +20,8 @@ import lombok.Builder;
 public class MenuItemReview {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
     private long itemId;
-  
     private String reviewerEmail;
     private int stars;  
     private LocalDateTime dateReviewed;

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -6,7 +6,4 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long>  {
-    Iterable<MenuItemReview> findAllByReviewerEmail(String reviewerEmail);
-
-}
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long>  {}

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -35,13 +35,13 @@
                 },
                 {
                   "column": {
-                    "name": "ITEMID", 
+                    "name": "ITEM_ID", 
                     "type": "BIGINT"
                   }
                 },
                 {
                   "column": {
-                    "name": "REVIEWEREMAIL", 
+                    "name": "REVIEWER_EMAIL", 
                     "type": "VARCHAR(255)"
                   }
                 },
@@ -53,7 +53,7 @@
                 },
                 {
                   "column": {
-                    "name": "DATEREVIEWED",
+                    "name": "DATE_REVIEWED",
                     "type": "TIMESTAMP"
                   }
                 },


### PR DESCRIPTION
Added GET, PUT, DELETE for MenuItemReviews. Works both locally and on dokku. 100% on jacoco and pitest.
Fixed Server Error 500, now all functions properly work 200 ok!
Deployed on https://team02-yuji-sakaguchi-dev.dokku-14.cs.ucsb.edu/

Closes https://github.com/ucsb-cs156-s24/team02-s24-5pm-6/issues/28
Closes https://github.com/ucsb-cs156-s24/team02-s24-5pm-6/issues/29
Closes https://github.com/ucsb-cs156-s24/team02-s24-5pm-6/issues/30